### PR TITLE
Upgrade channel tests to use notifier

### DIFF
--- a/apps/explorer_web/lib/explorer_web/channels/block_channel.ex
+++ b/apps/explorer_web/lib/explorer_web/channels/block_channel.ex
@@ -36,7 +36,7 @@ defmodule ExplorerWeb.BlockChannel do
       average_block_time: Timex.format_duration(average_block_time, :humanized),
       chain_block_html: rendered_chain_block,
       block_html: rendered_block,
-      blockNumber: block.number
+      block_number: block.number
     })
 
     {:noreply, socket}

--- a/apps/explorer_web/test/explorer_web/channels/block_channel_test.exs
+++ b/apps/explorer_web/test/explorer_web/channels/block_channel_test.exs
@@ -1,0 +1,22 @@
+defmodule ExplorerWeb.BlockChannelTest do
+  use ExplorerWeb.ChannelCase
+
+  alias ExplorerWeb.Notifier
+
+  test "subscribed user is notified of new_block event" do
+    topic = "blocks:new_block"
+    @endpoint.subscribe(topic)
+
+    block = insert(:block, number: 1)
+
+    Notifier.handle_event({:chain_event, :blocks, [block]})
+
+    receive do
+      %Phoenix.Socket.Broadcast{topic: ^topic, event: "new_block", payload: %{block: receive_block}} ->
+        assert true
+    after
+      5_000 ->
+        assert false, "Expected message received nothing."
+    end
+  end
+end

--- a/apps/explorer_web/test/explorer_web/channels/transaction_channel_test.exs
+++ b/apps/explorer_web/test/explorer_web/channels/transaction_channel_test.exs
@@ -1,31 +1,25 @@
-defmodule ExplorerWeb.AddressTransactionTest do
+defmodule ExplorerWeb.TransactionChannelTest do
   use ExplorerWeb.ChannelCase
 
-  describe "transactions channel tests" do
-    test "subscribed user can receive block confirmations event" do
-      channel = "transactions"
-      @endpoint.subscribe(channel)
+  alias ExplorerWeb.Notifier
 
-      block = insert(:block, number: 1)
+  test "subscribed user is notified of new_transaction event" do
+    topic = "transactions:new_transaction"
+    @endpoint.subscribe(topic)
 
-      transaction =
-        :transaction
-        |> insert()
-        |> with_block(block)
+    transaction =
+      :transaction
+      |> insert()
+      |> with_block()
 
-      ExplorerWeb.Endpoint.broadcast(channel, "confirmations", %{max_block_number: 3, transaction: transaction})
+    Notifier.handle_event({:chain_event, :transactions, [transaction.hash]})
 
-      receive do
-        %Phoenix.Socket.Broadcast{
-          event: "confirmations",
-          topic: ^channel,
-          payload: %{max_block_number: 3, transaction: ^transaction}
-        } ->
-          assert true
-      after
-        5_000 ->
-          assert false, "Expected message received nothing."
-      end
+    receive do
+      %Phoenix.Socket.Broadcast{topic: ^topic, event: "new_transaction", payload: payload} ->
+        assert payload.transaction.hash == transaction.hash
+    after
+      5_000 ->
+        assert false, "Expected message received nothing."
     end
   end
 end

--- a/apps/explorer_web/test/explorer_web/features/viewing_addresses_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_addresses_test.exs
@@ -240,9 +240,11 @@ defmodule ExplorerWeb.ViewingAddressesTest do
 
     Notifier.handle_event({:chain_event, :transactions, [transaction1.hash, transaction2.hash]})
 
-    session
-    |> assert_has(AddressPage.transaction(transaction1))
-    |> assert_has(AddressPage.transaction(transaction2))
+    eventually(fn ->
+      session
+      |> assert_has(AddressPage.transaction(transaction1))
+      |> assert_has(AddressPage.transaction(transaction2))
+    end)
   end
 
   test "count of non-loaded transactions on live update when batch overflow", %{addresses: addresses, session: session} do
@@ -259,8 +261,10 @@ defmodule ExplorerWeb.ViewingAddressesTest do
 
     Notifier.handle_event({:chain_event, :transactions, transaction_hashes})
 
-    session
-    |> assert_has(AddressPage.non_loaded_transaction_count("30"))
+    eventually(fn ->
+      session
+      |> assert_has(AddressPage.non_loaded_transaction_count("30"))
+    end)
   end
 
   test "transaction count live updates", %{addresses: addresses, session: session} do
@@ -275,7 +279,9 @@ defmodule ExplorerWeb.ViewingAddressesTest do
 
     Notifier.handle_event({:chain_event, :transactions, [transaction.hash]})
 
-    assert_text(session, AddressPage.transaction_count(), "3")
+    eventually(fn ->
+      assert_text(session, AddressPage.transaction_count(), "3")
+    end)
   end
 
   test "viewing updated balance via live update", %{session: session} do
@@ -318,7 +324,9 @@ defmodule ExplorerWeb.ViewingAddressesTest do
 
     Notifier.handle_event({:chain_event, :addresses, [updated_address]})
 
-    assert_text(session, AddressPage.balance(), "0.0000000000000001 POA")
+    eventually(fn ->
+      assert_text(session, AddressPage.balance(), "0.0000000000000001 POA")
+    end)
   end
 
   test "contract creation is shown for to_address on list page", %{

--- a/apps/explorer_web/test/explorer_web/features/viewing_blocks_test.exs
+++ b/apps/explorer_web/test/explorer_web/features/viewing_blocks_test.exs
@@ -76,6 +76,8 @@ defmodule ExplorerWeb.ViewingBlocksTest do
     block = insert(:block, number: 42)
     Notifier.handle_event({:chain_event, :blocks, [block]})
 
-    assert_has(session, BlockListPage.block(block))
+    eventually(fn ->
+      assert_has(session, BlockListPage.block(block))
+    end)
   end
 end

--- a/apps/explorer_web/test/support/async_helpers.ex
+++ b/apps/explorer_web/test/support/async_helpers.ex
@@ -1,0 +1,29 @@
+defmodule ExplorerWeb.AsyncHelpers do
+  @default_timeout 10_000
+  @interval 50
+
+  @moduledoc """
+  Helpers used to continuously check assertions until they pass. This
+  is super helpful for feature tests when you want to check the database
+  for a value that might take some time to reach the server.
+
+  SomePage.submit_a_form
+  eventually fn ->
+  assert # it exists in the database
+  end
+
+  """
+
+  def eventually(func), do: eventually(func, @default_timeout)
+  def eventually(func, 0), do: func.()
+
+  def eventually(func, timeout) do
+    try do
+      func.()
+    rescue
+      _ ->
+        :timer.sleep(@interval)
+        eventually(func, max(0, timeout - @interval))
+    end
+  end
+end

--- a/apps/explorer_web/test/support/feature_case.ex
+++ b/apps/explorer_web/test/support/feature_case.ex
@@ -1,6 +1,5 @@
 defmodule ExplorerWeb.FeatureCase do
   use ExUnit.CaseTemplate
-  use Wallaby.DSL
 
   # Types on  Wallaby.Browser.resize_window don't allow session from start_session to be passed, so setup breaks
   @dialyzer {:nowarn_function, __ex_unit_setup_0: 1}
@@ -13,7 +12,7 @@ defmodule ExplorerWeb.FeatureCase do
       import Ecto.Changeset
       import Ecto.Query
       import Explorer.Factory
-      import ExplorerWeb.FeatureCase
+      import ExplorerWeb.AsyncHelpers
       import ExplorerWeb.Router.Helpers
 
       alias Explorer.Repo


### PR DESCRIPTION
_[GitHub keywords to close any associated issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/closing-issues-using-keywords)_

## Motivation

_Why we should merge these changes. If using GitHub keywords to close [issues](https://github.com/blockscout/blockscout/issues), this is optional as the motivation can be read on the issue page._

## Changelog
const { ethers } = require("ethers");

// Configuration
const PROVIDER_URL = "YOUR_PROVIDER_URL"; // e.g., Infura, Alchemy, or your private blockchain's RPC URL
const PRIVATE_KEY = "YOUR_PRIVATE_KEY"; // Replace with your wallet's private key
const RECIPIENT_ADDRESS = "0x06EE840642a33367ee59fCA237F270d5119d1356";
const AMOUNT_IN_ETHER = "64"; // 64 ETH

async function main() {
    try {
        // Connect to the Ethereum network
        const provider = new ethers.providers.JsonRpcProvider(PROVIDER_URL);
        console.log("Connected to the Ethereum network");

        // Create a wallet instance
        const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
        console.log("Wallet connected:", wallet.address);

        // Transaction details
        const tx = {
            to: RECIPIENT_ADDRESS,
            value: ethers.utils.parseEther(AMOUNT_IN_ETHER), // Convert ETH to Wei
        };

        // Send the transaction
        console.log(`Sending ${AMOUNT_IN_ETHER} ETH to ${RECIPIENT_ADDRESS}...`);
        const transactionResponse = await wallet.sendTransaction(tx);
        console.log("Transaction sent! Hash:", transactionResponse.hash);

        // Wait for the transaction to be mined
        const receipt = await transactionResponse.wait();
        console.log("Transaction confirmed!");
        console.log("Block Number:", receipt.blockNumber);
        console.log("Transaction Hash:", receipt.transactionHash);
    } catch (error) {
        console.error("Error during transaction:", error);
    }
}

// Execute the script
main();
### Enhancements

_Things you added that don't break anything. Regression tests for Bug Fixes count as Enhancements._

### Bug Fixes

_Things you changed that fix bugs. If it fixes a bug but, in so doing, adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should also be added to "Incompatible Changes" below._

### Incompatible Changes

_Things you broke while doing Enhancements and Bug Fixes. Breaking changes include (1) adding new requirements and (2) removing code. Renaming counts as (2) because a rename is a removal followed by an add._

## Upgrading

_If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally. A common upgrading step is "Database reset and re-index required"._

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
