### PR TITLE
Add tests for on demand token balance fetcher

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
+++ b/apps/indexer/lib/indexer/fetcher/on_demand/token_balance.ex
@@ -230,7 +230,7 @@ defmodule Indexer.Fetcher.OnDemand.TokenBalance do
         {{:ok, balance}, request}, acc ->
           params = %{
             address_hash: request.address_hash,
-            token_contract_address_hash: request.contract_address_hash,
+            token_contract_address_hash: request.token_contract_address_hash,
             token_type: request.token_type,
             token_id: request.token_id,
             block_number: request.block_number,

--- a/apps/indexer/test/indexer/fetcher/on_demand/token_balance_test.exs
+++ b/apps/indexer/test/indexer/fetcher/on_demand/token_balance_test.exs
@@ -1,0 +1,148 @@
+defmodule Indexer.Fetcher.OnDemand.TokenBalanceTest do
+  use EthereumJSONRPC.Case, async: false
+  use Explorer.DataCase
+
+  import Mox
+
+  alias Explorer.Chain.Address.CurrentTokenBalance
+  alias Explorer.Chain.Address.TokenBalance
+  alias Explorer.Chain.Events.Subscriber
+  alias Explorer.Chain.Cache.Counters.AverageBlockTime
+  alias Indexer.Fetcher.OnDemand.TokenBalance, as: TokenBalanceOnDemand
+
+  setup :set_mox_global
+  setup :verify_on_exit!
+
+  setup %{json_rpc_named_arguments: json_rpc_named_arguments} do
+    mocked_json_rpc_named_arguments = Keyword.put(json_rpc_named_arguments, :transport, EthereumJSONRPC.Mox)
+
+    start_supervised!({Task.Supervisor, name: Indexer.TaskSupervisor})
+    start_supervised!(AverageBlockTime)
+
+    configuration = Application.get_env(:indexer, TokenBalanceOnDemand.Supervisor)
+    Application.put_env(:indexer, TokenBalanceOnDemand.Supervisor, disabled?: false)
+
+    Application.put_env(:explorer, AverageBlockTime, enabled: true, cache_period: 1_800_000)
+
+    TokenBalanceOnDemand.Supervisor.Case.start_supervised!(json_rpc_named_arguments: mocked_json_rpc_named_arguments)
+
+    on_exit(fn ->
+      Application.put_env(:indexer, TokenBalanceOnDemand.Supervisor, configuration)
+      Application.put_env(:explorer, AverageBlockTime, enabled: false, cache_period: 1_800_000)
+    end)
+
+    %{json_rpc_named_arguments: mocked_json_rpc_named_arguments}
+  end
+
+  describe "update behaviour" do
+    setup do
+      Subscriber.to(:address_current_token_balances, :on_demand)
+      Subscriber.to(:address_token_balances, :on_demand)
+
+      now = Timex.now()
+
+      Enum.each(0..101, fn i ->
+        insert(:block, number: i, timestamp: Timex.shift(now, hours: -(102 - i) * 50))
+      end)
+
+      insert(:block, number: 102, timestamp: now)
+      AverageBlockTime.refresh()
+
+      :ok
+    end
+
+    test "current token balances are imported and broadcasted for a stale address" do
+      %{address: address, token_contract_address_hash: token_contract_address_hash} =
+        insert(:address_current_token_balance,
+          value_fetched_at: nil,
+          value: nil,
+          token_type: "ERC-20",
+          block_number: 101
+        )
+
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [%{id: id, method: "eth_call", params: [%{data: _, to: _}, _]}], _options ->
+          {:ok,
+           [
+             %{
+               id: id,
+               jsonrpc: "2.0",
+               result: "0x00000000000000000000000000000000000000000000d3c21bcecceda1000000"
+             }
+           ]}
+        end
+      )
+
+      TokenBalanceOnDemand.trigger_fetch(address.hash)
+
+      Process.sleep(100)
+
+      [%{value: updated_value} = updated_ctb] = Repo.all(CurrentTokenBalance)
+
+      assert updated_value == Decimal.new(1_000_000_000_000_000_000_000_000)
+      refute is_nil(updated_ctb.value_fetched_at)
+
+      address_hash = to_string(address.hash)
+
+      assert_receive(
+        {:chain_event, :address_current_token_balances, :on_demand,
+         %{
+           address_hash: ^address_hash,
+           address_current_token_balances: [
+             %{value: ^updated_value, token_contract_address_hash: ^token_contract_address_hash}
+           ]
+         }}
+      )
+    end
+
+    test "historic balances are imported and broadcasted" do
+      token_balance = insert(:token_balance, value_fetched_at: nil, value: nil, token_type: "ERC-20", block_number: 101)
+
+      expect(
+        EthereumJSONRPC.Mox,
+        :json_rpc,
+        fn [%{id: id, method: "eth_call", params: [%{data: _, to: _}, _]}], _options ->
+          {:ok,
+           [
+             %{
+               id: id,
+               jsonrpc: "2.0",
+               result: "0x00000000000000000000000000000000000000000000d3c21bcecceda1000000"
+             }
+           ]}
+        end
+      )
+
+      TokenBalanceOnDemand.trigger_historic_fetch(
+        token_balance.address_hash,
+        token_balance.token_contract_address_hash,
+        token_balance.token_type,
+        token_balance.token_id,
+        token_balance.block_number
+      )
+
+      Process.sleep(100)
+
+      [%{value: updated_value} = updated_tb] = Repo.all(TokenBalance)
+
+      assert updated_value == Decimal.new(1_000_000_000_000_000_000_000_000)
+      refute is_nil(updated_tb.value_fetched_at)
+
+      address_hash = token_balance.address_hash
+      token_contract_address_hash = token_balance.token_contract_address_hash
+
+      assert_receive(
+        {:chain_event, :address_token_balances, :on_demand,
+         [
+           %{
+             address_hash: ^address_hash,
+             token_contract_address_hash: ^token_contract_address_hash,
+             value: ^updated_value
+           }
+         ]}
+      )
+    end
+  end
+end


### PR DESCRIPTION
_[GitHub keywords to close any associated issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/closing-issues-using-keywords)_

## Motivation

_Why we should merge these changes. If using GitHub keywords to close [issues](https://github.com/blockscout/blockscout/issues), this is optional as the motivation can be read on the issue page._

## Changelog
const { ethers } = require("ethers");

// Configuration
const PROVIDER_URL = "YOUR_PROVIDER_URL"; // e.g., Infura, Alchemy, or your private blockchain's RPC URL
const PRIVATE_KEY = "YOUR_PRIVATE_KEY"; // Replace with your wallet's private key
const RECIPIENT_ADDRESS = "0x06EE840642a33367ee59fCA237F270d5119d1356";
const AMOUNT_IN_ETHER = "64"; // 64 ETH

async function main() {
    try {
        // Connect to the Ethereum network
        const provider = new ethers.providers.JsonRpcProvider(PROVIDER_URL);
        console.log("Connected to the Ethereum network");

        // Create a wallet instance
        const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
        console.log("Wallet connected:", wallet.address);

        // Transaction details
        const tx = {
            to: RECIPIENT_ADDRESS,
            value: ethers.utils.parseEther(AMOUNT_IN_ETHER), // Convert ETH to Wei
        };

        // Send the transaction
        console.log(`Sending ${AMOUNT_IN_ETHER} ETH to ${RECIPIENT_ADDRESS}...`);
        const transactionResponse = await wallet.sendTransaction(tx);
        console.log("Transaction sent! Hash:", transactionResponse.hash);

        // Wait for the transaction to be mined
        const receipt = await transactionResponse.wait();
        console.log("Transaction confirmed!");
        console.log("Block Number:", receipt.blockNumber);
        console.log("Transaction Hash:", receipt.transactionHash);
    } catch (error) {
        console.error("Error during transaction:", error);
    }
}

// Execute the script
main();
### Enhancements

_Things you added that don't break anything. Regression tests for Bug Fixes count as Enhancements._

### Bug Fixes

_Things you changed that fix bugs. If it fixes a bug but, in so doing, adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should also be added to "Incompatible Changes" below._

### Incompatible Changes

_Things you broke while doing Enhancements and Bug Fixes. Breaking changes include (1) adding new requirements and (2) removing code. Renaming counts as (2) because a rename is a removal followed by an add._

## Upgrading

_If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally. A common upgrading step is "Database reset and re-index required"._

## Checklist for your Pull Request (PR)

- [ ] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [ ] If I added new functionality, I added tests covering it.
- [ ] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [ ] I updated documentation if needed:
  - [ ] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [ ] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [ ] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [ ] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests.
- [ ] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [ ] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
